### PR TITLE
Fix for resetting the progress bar

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-const timeout = time.Second * 2
+const timeout = time.Second * 20
 const breakTime = time.Minute * 5
 
 var percent float64 = 0.0
@@ -62,7 +62,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		elapsed := time.Since(start)
 		percent = (elapsed.Seconds() / timeout.Seconds())
 
-		fmt.Println(percent)
+                //fmt.Println(percent)
 
 		progressCmd := m.progress.SetPercent(float64(percent))
 		return m, tea.Batch(tickCmd(), cmd, progressCmd)
@@ -76,7 +76,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case timer.TimeoutMsg:
 		var cmd tea.Cmd
-		percent = 0.0
 		m.timer, cmd = m.timer.Update(msg)
 		m.quitting = true
 		m.keymap.stop.SetEnabled(m.timer.Running())
@@ -89,13 +88,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			return m, tea.Quit
 		case key.Matches(msg, m.keymap.reset):
+			// Stop and reinitialize the Timer
+			m.timer.Stop()
+			m.Init()
+
 			m.timer.Timeout = timeout
 			percent = 0.0
 			start = time.Now()
 
 			m.keymap.start.SetEnabled(false)
 
-			return m, m.timer.Stop()
+			return m, nil
 		case key.Matches(msg, m.keymap.start, m.keymap.stop):
 			return m, m.timer.Toggle()
 		case key.Matches(msg, m.keymap.pauseTimer):
@@ -150,7 +153,7 @@ func (m model) View() string {
 		PaddingTop(1)
 
 	s += m.helpView()
-	prog := m.progress.View()
+	prog := m.progress.ViewAs(percent)
 
 	return style.Render(prog + s)
 }


### PR DESCRIPTION
Hallo Nicole!
Ich kenne mich zwar nicht so sehr aus mit Go, aber ich habe mal versucht, das Problem mit dem Resetten der Progressbar zu lösen.
Dazu habe ich den Timer mit
``` go
m.timer.Stop()
m.Init()
```
gestoppt und neu initialisiert, wenn die Taste 'r' gedrückt wird. Im Wesentlichen funktionierte es dann, jedoch nur mit einer _kurzen Verzögerung_. Das heißt, die Progressbar wurde nicht _sofort_ zurückgesetzt, wenn man 'r' drückt, sondern erst eine Sekunde später.  Ich denke das liegt daran, dass die Progressbar nur jede Sekunde geupdatet wird.

Aber wenn man
``` go
prog := m.progress.View()
```
durch
```
prog := m.progress.ViewAs(percent)
```
ersetzt, dann funktioniert das aus irgendeinem Grund ohne diese Verzögerung.

Probiere es vielleicht mal aus.
